### PR TITLE
Update libtimezonemap to version 0.4.0

### DIFF
--- a/libtimezonemap/PKGBUILD
+++ b/libtimezonemap/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Xiao-Long Chen <chenxiaolong@cxl.epac.to>
 
 pkgname=libtimezonemap
-pkgver=0.3.2
-pkgrel=100
+pkgver=0.4.0
+pkgrel=1
 pkgdesc="GTK+3 timezone map widget"
 arch=('i686' 'x86_64')
 url="https://launchpad.net/libtimezonemap"
@@ -12,22 +12,22 @@ depends=('gtk3' 'json-glib')
 makedepends=('gobject-introspection' 'intltool')
 options=('!libtool')
 source=("https://launchpad.net/ubuntu/+archive/primary/+files/${pkgname}_${pkgver}.tar.gz")
-sha512sums=('4a82794c2ae0497768470ffb34df6dffda567ca0f1d63e991260a88898c5a731dcdb51796a8cb974b6f2d4fc2da2576cdf8678cbd92da5eae2f869b89b4b9017')
+sha512sums=('70906b837aa295a0e7de116576f5f25f865ab1af2258e4fb9233e5e693e3ac71a324c6c22500ba29520de3e90c19c6977fa2aceb1e0f7154a4bcd70ee887eb68')
 
 build() {
-  cd "${srcdir}/${pkgname/lib/}"
+  cd "${srcdir}/${pkgname}-${pkgver}"
   autoreconf -vfi
   ./configure --prefix=/usr --enable-introspection --with-gtk=3
-  make ${MAKEFLAGS}
+  make
 }
 
 check() {
-  cd "${srcdir}/${pkgname/lib/}"
+  cd "${srcdir}/${pkgname}-${pkgver}"
   make -k check
 }
 
 package() {
-  cd "${srcdir}/${pkgname/lib/}"
+  cd "${srcdir}/${pkgname}-${pkgver}"
   make DESTDIR="${pkgdir}/" install
 }
 


### PR DESCRIPTION
The current version, 0.3.2, no longer compiles with the latest Arch packages. The new version has no compatibility issues with Cnchi that I can see.
