### PR TITLE
Added Gnome 3.14.2 to LightDM Lockscreen's metadata.json

### DIFF
--- a/gnome-shell-extension-lockscreen-lightdm/metadata.json
+++ b/gnome-shell-extension-lockscreen-lightdm/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "3.10", 
     "3.12",
-    "3.14"
+    "3.14",
+    "3.14.2"
   ], 
   "url": "https://github.com/Antergos", 
   "uuid": "lockscreen@dev.antergos.com", 


### PR DESCRIPTION
I updated the metadata.json file for the LightDM Lockscreen Gnome extension.
