### PR TITLE
And symlink to droboxd in /usr/bin,

### DIFF
--- a/cnchi-dev/PKGBUILD
+++ b/cnchi-dev/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=Cnchi
 pkgname=cnchi-dev
 pkgver=0.7.200
-pkgrel=4
+pkgrel=5
 pkgdesc='Antergos Installer - Development Version'
 arch=(any)
 license=(GPL)

--- a/cnchi-dev/PKGBUILD
+++ b/cnchi-dev/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=Cnchi
 pkgname=cnchi-dev
 pkgver=0.7.200
-pkgrel=3
+pkgrel=4
 pkgdesc='Antergos Installer - Development Version'
 arch=(any)
 license=(GPL)

--- a/cnchi-dev/PKGBUILD
+++ b/cnchi-dev/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=Cnchi
 pkgname=cnchi-dev
 pkgver=0.7.200
-pkgrel=2
+pkgrel=3
 pkgdesc='Antergos Installer - Development Version'
 arch=(any)
 license=(GPL)

--- a/dropbox/dropbox.install
+++ b/dropbox/dropbox.install
@@ -1,6 +1,7 @@
 post_install() {
 
     ln -sf /opt/dropbox/dropbox /usr/bin/dropbox
+    ln -sf /opt/dropbox/dropboxd /usr/bin/dropboxd
     if [[ -d "${HOME}/.dropbox-dist" ]]; then
         rm -R "${HOME}/.dropbox-dist"
     fi
@@ -19,6 +20,7 @@ post_upgrade() {
 
 post_remove() {
   unlink -f /usr/bin/dropbox
+  unlink -f /usr/bin/dropboxd
   rm -R "${HOME}/.dropbox-dist"
   rm -R "${HOME}/.config/dropbox.desktop"
 }


### PR DESCRIPTION
The dropbox.desktop files execute dropboxd, hence it must be placed in a $PATH directory.