### PR TITLE
Fixes KDE install in Cnchi

### DIFF
--- a/antergos-kde-setup/PKGBUILD
+++ b/antergos-kde-setup/PKGBUILD
@@ -15,7 +15,7 @@ depends=('ark' 'aspell-en' 'breeze' 'breeze-gtk' 'breeze-kde4' 'cdrdao' 'clement
 	'kfaenza-icon-theme' 'kipi-plugins' 'khelpcenter' 'kinfocenter' 'kmenuedit' 'konsole'
 	'kscreen' 'ksshaskpass' 'ksysguard' 'kwallet-pam' 'kwalletmanager' 'kwayland-integration'
 	'kwin' 'kwrited' 'milou' 'nm-connection-editor' 'numix-frost-themes'
-	'numix-icon-theme-square' 'oxygen' 'oxygen-cursors' 'plasma-desktop' 'plasma-nm'
+	'numix-icon-theme-square' 'oxygen' 'plasma-desktop' 'plasma-nm'
 	'plasma-pa' 'plasma-workspace' 'plasma-workspace-wallpapers' 'powerdevil' 'qtcurve-qt5'
 	'qtcurve-qt4' 'qtcurve-gtk2' 'spectacle' 'systemsettings' 'transmission-qt' 'user-manager'
 	'vlc' 'xdg-user-dirs')


### PR DESCRIPTION
Oxygen replaces oxygen-cursors

https://www.archlinux.org/packages/extra/x86_64/oxygen/