### PR TITLE
Add missing dependecy for 'python-dbus'

### DIFF
--- a/antergos/cinnamon/cinnamon/PKGBUILD
+++ b/antergos/cinnamon/cinnamon/PKGBUILD
@@ -20,8 +20,8 @@ depends=('accountsservice'          'cjs'                    'libkeybinder3'    
 		 'cinnamon-screensaver'     'gconf'                 'network-manager-applet' 'python2-ptyprocess'
 		 'cinnamon-session'                                 'polkit-gnome'           'python2-pyinotify'
 		 'cinnamon-settings-daemon' 'libgnomekbd'           'python2-cairo'          'webkitgtk'
-		 'cinnamon-translations'    'libgnome-keyring'      'python2-dbus'           'xapps'
-		 'wget'                     'iso-flag-png')
+		 'cinnamon-translations'    'libgnome-keyring'      'python-dbus'            'python2-dbus'
+		 'xapps'                    'wget'                  'iso-flag-png')
 
 makedepends=('autoconf-archive' 'intltool' 'gtk-doc' 'gobject-introspection')
 conflicts=('mint-cinnamon-themes')


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'dbus'` in `cinnamon-subprocess-wrapper`. 

For example due to this Cinnamon was not able to show album cover in sound applet (for example from Spotify).