### PR TITLE
Clean up. Stage one of removing it from packages repo into 'cnchi' repo

### DIFF
--- a/antergos/cnchi/PKGBUILD
+++ b/antergos/cnchi/PKGBUILD
@@ -9,9 +9,9 @@ pkgdesc='A modern, flexible system installer for Linux'
 arch=('any')
 license=('GPL3')
 url='https://github.com/Antergos/Cnchi'
-depends=('python' 'pyalpm' 'python-gobject' 'python-dbus' 'python-cairo' 'python-requests'
-		'python-parted' 'webkit2gtk' 'upower' 'python-mako' 'iso-codes' 'gptfdisk'
-		'python-bugsnag' 'upower')
+depends=('python' 'pyalpm' 'python-gobject' 'python-dbus' 'python-cairo'
+        'python-requests' 'python-parted' 'webkit2gtk' 'upower' 'python-mako'
+        'iso-codes' 'gptfdisk' 'python-bugsnag')
 conflicts=('cnchi-dev')
 source=("${_pkgname}-${pkgver}.tar.gz::https://github.com/antergos/cnchi/archive/${pkgver}.tar.gz")
 sha256sums=('693da2b4ef8c50ef4f51d325bb0a7710e9ed2762b1a573cb711d29095622b746')

--- a/antergos/cnchi/PKGBUILD
+++ b/antergos/cnchi/PKGBUILD
@@ -1,3 +1,4 @@
+# $Id$
 # Maintainer: Antergos Developers <dev@antergos.com>
 
 pkgname=cnchi
@@ -12,9 +13,8 @@ depends=('python' 'pyalpm' 'python-gobject' 'python-dbus' 'python-cairo' 'python
 		'python-parted' 'webkit2gtk' 'upower' 'python-mako' 'iso-codes' 'gptfdisk'
 		'python-bugsnag' 'upower')
 conflicts=('cnchi-dev')
-source=("${_pkgname}-${pkgver}.zip::https://github.com/antergos/cnchi/archive/${pkgver}.zip")
-md5sums=('40f996c8a36baa1b5ce8f14acc43d8ca')
-
+source=("${_pkgname}-${pkgver}.tar.gz::https://github.com/antergos/cnchi/archive/${pkgver}.tar.gz")
+sha256sums=('693da2b4ef8c50ef4f51d325bb0a7710e9ed2762b1a573cb711d29095622b746')
 
 # BEGIN ANTBS METADATA
 _is_monitored='True'
@@ -23,12 +23,6 @@ _monitored_type='releases'
 _monitored_project='antergos'
 _monitored_repo='cnchi'
 # END ANTBS METADATA
-
-
-build() {
-	cp -R ../po "${srcdir}/${_pkgname}-${pkgver}"
-}
-
 
 package() {
 	cd "${srcdir}/${_pkgname}-${pkgver}"
@@ -39,7 +33,7 @@ package() {
         install -Dm644 "data/images/antergos/antergos-icon.png" "${pkgdir}/usr/share/pixmaps/cnchi.png"
 
 	sed -r -i 's|\/usr.+ -v|pkexec /usr/share/cnchi/bin/cnchi -s bugsnag|g' "${pkgdir}/usr/bin/cnchi"
-	
+
 	for i in cnchi bin data scripts ui; do
 		cp -R ${i} "${pkgdir}/usr/share/cnchi/"
 	done
@@ -54,5 +48,3 @@ package() {
 		fi
 	done
 }
-
-# -*- mode: bash;-*-

--- a/antergos/cnchi/PKGBUILD
+++ b/antergos/cnchi/PKGBUILD
@@ -30,7 +30,7 @@ package() {
 	install -d ${pkgdir}/usr/share/{cnchi,locale}
 	install -Dm755 "bin/${pkgname}" "${pkgdir}/usr/bin/cnchi"
 	install -Dm755 "${pkgname}.desktop" "${pkgdir}/usr/share/applications/cnchi.desktop"
-        install -Dm644 "data/images/antergos/antergos-icon.png" "${pkgdir}/usr/share/pixmaps/cnchi.png"
+    install -Dm644 "data/images/antergos/antergos-icon.png" "${pkgdir}/usr/share/pixmaps/cnchi.png"
 
 	sed -r -i 's|\/usr.+ -v|pkexec /usr/share/cnchi/bin/cnchi -s bugsnag|g' "${pkgdir}/usr/bin/cnchi"
 


### PR DESCRIPTION
* Clean up. Stage one of removing it from packages repo into 'cnchi' repo.

* Use ''.tar.gz.'' Smaller downloads are always best. Especially when you
  are doing hundreds/thousands sometimes.

* Local minimal hassle builds can be done by downloading packages:

    - pyhton-bugsnag
    - python-parted

  Place in same folder as 'PKGBUILD' file. After this to do a build:

    makechrootpkg -c -r $CHROOT -I python-bugsnag-2.5.0-1-any.pkg.tar.xz -I python-parted-3.10.7-4-x86_64.pkg.tar.xz

  Note: Version numbers may differ at future build time.

Did not touch ABS data.