### PR TITLE
Drop unneeded dependency to 'webkitgtk'

### DIFF
--- a/antergos/cinnamon/cinnamon/PKGBUILD
+++ b/antergos/cinnamon/cinnamon/PKGBUILD
@@ -19,8 +19,8 @@ depends=('accountsservice'          'cjs'                    'libkeybinder3'    
 		                            'gnome-themes-standard' 'networkmanager'         'python2-pillow'
 		 'cinnamon-screensaver'     'gconf'                 'network-manager-applet' 'python2-ptyprocess'
 		 'cinnamon-session'                                 'polkit-gnome'           'python2-pyinotify'
-		 'cinnamon-settings-daemon' 'libgnomekbd'           'python2-cairo'          'webkitgtk'
-		 'cinnamon-translations'    'libgnome-keyring'      'python-dbus'            'python2-dbus'
+		 'cinnamon-settings-daemon' 'libgnomekbd'           'python2-cairo'          'cinnamon-translations'
+		 'libgnome-keyring'	    'python-dbus'           'python2-dbus'
 		 'xapps'                    'wget'                  'iso-flag-png')
 
 makedepends=('autoconf-archive' 'intltool' 'gtk-doc' 'gobject-introspection')


### PR DESCRIPTION
As Arch package says `WebKitGTK+2.4 is known to have many security vulnerabilities that will not be fixed.` Is is NOT needed by Cinnamon at all anyway, so there is no point of having it there.