### PR TITLE
Remove zlib_deflate from zfs-utils.initcpio.install

### DIFF
--- a/antergos/zfs-utils/zfs-utils.initcpio.install
+++ b/antergos/zfs-utils/zfs-utils.initcpio.install
@@ -9,8 +9,7 @@ build() {
         zfs \
         zpios \
         spl \
-        splat \
-        zlib_deflate
+        splat 
 
     map add_binary \
         arcstat.py \


### PR DESCRIPTION
This module does not need to be added as it's now a built-in. This will
resolve the following error during a kernel upgrade:
```
Updating linux initcpios
==> Building image from preset: /etc/mkinitcpio.d/linux.preset: 'default'
  -> -k /boot/vmlinuz-linux -c /etc/mkinitcpio.conf -g /boot/initramfs-linux.img
==> Starting build: 4.12.13-1-ARCH
  -> Running build hook: [base]
  -> Running build hook: [udev]
  -> Running build hook: [autodetect]
  -> Running build hook: [modconf]
  -> Running build hook: [block]
  -> Running build hook: [keyboard]
  -> Running build hook: [keymap]
  -> Running build hook: [resume]
  -> Running build hook: [zfs]
==> ERROR: module not found: `zlib_deflate'
  -> Running build hook: [filesystems]
==> Generating module dependencies
==> Creating gzip-compressed initcpio image: /boot/initramfs-linux.img
==> WARNING: errors were encountered during the build. The image may not be complete.
```

This was fixed successfully in the archzfs package - https://github.com/archzfs/archzfs/pull/119