### PR TITLE
Init script syntax cleanup

### DIFF
--- a/antergos/zfs-utils/zfs-utils.initcpio.hook
+++ b/antergos/zfs-utils/zfs-utils.initcpio.hook
@@ -60,7 +60,7 @@ run_hook() {
     # Force import the pools, useful if the pool has not properly been exported
     # using 'zpool export <pool>'
     [ "${zfs_force}" != ""  ] && ZPOOL_FORCE='-f'
-    [[ "${zfs_import_dir}" != "" ]] && ZPOOL_IMPORT_FLAGS="${ZPOOL_IMPORT_FLAGS} -d ${zfs_import_dir}"
+    [ "${zfs_import_dir}" != "" ] && ZPOOL_IMPORT_FLAGS="${ZPOOL_IMPORT_FLAGS} -d ${zfs_import_dir}"
 
     if [ "$root" = 'zfs' ]; then
         mount_handler='zfs_mount_handler'

--- a/antergos/zfs-utils/zfs-utils.initcpio.hook
+++ b/antergos/zfs-utils/zfs-utils.initcpio.hook
@@ -21,10 +21,10 @@ zfs_get_bootfs () {
 
 zfs_mount_handler () {
     local node=$1
-    if [ "$ZFS_DATASET" = "bootfs" ] ; then
+    if [ "${ZFS_DATASET}" = "bootfs" ] ; then
         if ! zfs_get_bootfs ; then
             # Lets import everything and try again
-            /usr/bin/zpool import $ZPOOL_IMPORT_FLAGS -N -a $ZPOOL_FORCE
+            /usr/bin/zpool import ${ZPOOL_IMPORT_FLAGS} -N -a ${ZPOOL_FORCE}
             if ! zfs_get_bootfs ; then
                 echo "ZFS: Cannot find bootfs."
                 return 1
@@ -34,40 +34,39 @@ zfs_mount_handler () {
 
     local pool="${ZFS_DATASET%%/*}"
     local rwopt_exp=${rwopt:-ro}
-
-    if ! "/usr/bin/zpool" list -H $pool 2>&1 > /dev/null ; then
-        if [ "$rwopt_exp" != "rw" ]; then
-            msg "ZFS: Importing pool $pool readonly."
+    if ! "/usr/bin/zpool" list -H ${pool} 2>1 > /dev/null ; then
+        if [ "${rwopt_exp}" != "rw" ]; then
+            msg "ZFS: Importing pool {$pool} readonly."
             ZPOOL_IMPORT_FLAGS="$ZPOOL_IMPORT_FLAGS -o readonly=on"
         else
-            msg "ZFS: Importing pool $pool."
+            msg "ZFS: Importing pool ${pool}."
         fi
 
-        if ! "/usr/bin/zpool" import $ZPOOL_IMPORT_FLAGS -N $pool $ZPOOL_FORCE ; then
-            echo "ZFS: Unable to import pool $pool."
+        if ! "/usr/bin/zpool" import ${ZPOOL_IMPORT_FLAGS} -N ${pool} ${ZPOOL_FORCE} ; then
+            echo "ZFS: Unable to import pool ${pool}."
             return 1
         fi
     fi
 
-    local mountpoint=$("/usr/bin/zfs" get -H -o value mountpoint $ZFS_DATASET)
-    if [ "$mountpoint" = "legacy" ] ; then
-        mount -t zfs -o ${rwopt_exp} "$ZFS_DATASET" "$node"
+    local mountpoint=$("/usr/bin/zfs" get -H -o value mountpoint ${ZFS_DATASET})
+    if [ "${mountpoint}" = "legacy" ] ; then
+        mount -t zfs -o ${rwopt_exp} "${ZFS_DATASET}" "$node"
     else
-        mount -o zfsutil,${rwopt_exp} -t zfs "$ZFS_DATASET" "$node"
+        mount -o zfsutil,${rwopt_exp} -t zfs "${ZFS_DATASET}" "${node}"
     fi
 }
 
 run_hook() {
     # Force import the pools, useful if the pool has not properly been exported
     # using 'zpool export <pool>'
-    [[ $zfs_force == 1 ]] && ZPOOL_FORCE='-f'
-    [[ "$zfs_import_dir" != "" ]] && ZPOOL_IMPORT_FLAGS="$ZPOOL_IMPORT_FLAGS -d $zfs_import_dir"
+    [ "${zfs_force}" != ""  ] && ZPOOL_FORCE='-f'
+    [[ "${zfs_import_dir}" != "" ]] && ZPOOL_IMPORT_FLAGS="${ZPOOL_IMPORT_FLAGS} -d ${zfs_import_dir}"
 
     if [ "$root" = 'zfs' ]; then
         mount_handler='zfs_mount_handler'
     fi
 
-    case $zfs in
+    case ${zfs} in
         "")
             # skip this line/dataset
             ;;
@@ -94,7 +93,7 @@ run_hook() {
 
 
 run_latehook () {
-    /usr/bin/zpool import -N -a $ZPOOL_FORCE
+    /usr/bin/zpool import -N -a ${ZPOOL_FORCE}
 }
 
 # vim:set ts=4 sw=4 ft=sh et:


### PR DESCRIPTION
A couple minor Ash syntax issues were present in zfs-utils.initcpio.hook. I've referenced the changes in https://github.com/archzfs/archzfs/issues/48 and applied the bulk of them here. 

This resolves both error messages on boot when handling ZFS pools. 

I've run the script through 'checkbashisms', which is used to check for Bash-specific shell script syntax. 

```
$ checkbashisms zfs-utils.initcpio.hook 
script zfs-utils.initcpio.hook does not appear to have a #! interpreter line;
you may get strange results

```

The missing interpreter line is to be expected, as each hook is sourced from the parent 'init' script, which has the appropriate #! interpreter line.

Is there a long-term plan to share more code between the archzfs packages and Antergos's internal packages?  This seems like a good opportunity to reduce some duplicated work between the two package sets.