### PR TITLE
antergos-kde-* fix renamed packages

### DIFF
--- a/antergos/antergos-kde-meta/PKGBUILD
+++ b/antergos/antergos-kde-meta/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=antergos-kde-meta
 pkgver=1.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Meta package for Antergos KDE Plasma'
 url='http://www.antergos.com'
 arch=('any')
 license=('GPL3')
 depends=('ark' 'aspell-en' 'breeze' 'breeze-gtk' 'breeze-kde4' 'cdrdao' 'clementine' 'dolphin' 'dolphin-plugins' 'dvd+rw-tools' 'ffmpegthumbs'
-    'gwenview' 'k3b' 'kate' 'kcalc' 'kdeconnect' 'kdegraphics-thumbnailers' 'kde-gtk-config' 'kdelibs4support' 'kdenetwork-kopete'
-    'kde-servicemenus-rootactions' 'kdesudo' 'kdeutils-sweeper' 'kdialog' 'kfaenza-icon-theme' 'kfind' 'khelpcenter' 'kinfocenter'
+    'gwenview' 'k3b' 'kate' 'kcalc' 'kdeconnect' 'kdegraphics-thumbnailers' 'kde-gtk-config' 'kdelibs4support' 'kopete'
+    'kde-servicemenus-rootactions' 'kdesudo' 'sweeper' 'kdialog' 'kfaenza-icon-theme' 'kfind' 'khelpcenter' 'kinfocenter'
     'kipi-plugins' 'kmenuedit' 'konsole' 'kscreen' 'ksshaskpass' 'ksysguard' 'kwalletmanager' 'kwallet-pam' 'kwayland-integration' 'kwin'
     'kwrited' 'milou' 'nm-connection-editor' 'numix-frost-themes' 'numix-icon-theme-square' 'okular' 'oxygen' 'pamac-tray-appindicator'
     'plasma-desktop' 'plasma-nm' 'plasma-pa' 'plasma-workspace' 'plasma-workspace-wallpapers' 'powerdevil' 'qtcurve-gtk2' 'qtcurve-qt4'

--- a/antergos/antergos-kde-setup/PKGBUILD
+++ b/antergos/antergos-kde-setup/PKGBUILD
@@ -3,14 +3,14 @@
 pkgname=antergos-kde-setup
 _pkgname=antergos-desktop-settings
 pkgver=1.1
-pkgrel=3
+pkgrel=4
 pkgdesc='Setup configuration for Antergos KDE Plasma'
 url='http://github.com/Antergos/antergos-desktop-settings/plasma'
 arch=('any')
 license=('GPL3')
 depends=('ark' 'aspell-en' 'breeze' 'breeze-gtk' 'breeze-kde4' 'cdrdao' 'clementine' 'dolphin' 'dolphin-plugins' 'dvd+rw-tools' 'ffmpegthumbs'
-    'gwenview' 'k3b' 'kate' 'kcalc' 'kdeconnect' 'kdegraphics-thumbnailers' 'kde-gtk-config' 'kdelibs4support' 'kdenetwork-kopete'
-    'kde-servicemenus-rootactions' 'kdesudo' 'kdeutils-sweeper' 'kdialog' 'kfaenza-icon-theme' 'kfind' 'khelpcenter' 'kinfocenter'
+    'gwenview' 'k3b' 'kate' 'kcalc' 'kdeconnect' 'kdegraphics-thumbnailers' 'kde-gtk-config' 'kdelibs4support' 'kopete'
+    'kde-servicemenus-rootactions' 'kdesudo' 'sweeper' 'kdialog' 'kfaenza-icon-theme' 'kfind' 'khelpcenter' 'kinfocenter'
     'kipi-plugins' 'kmenuedit' 'konsole' 'kscreen' 'ksshaskpass' 'ksysguard' 'kwalletmanager' 'kwallet-pam' 'kwayland-integration' 'kwin'
     'kwrited' 'milou' 'nm-connection-editor' 'numix-frost-themes' 'numix-icon-theme-square' 'okular' 'oxygen' 'pamac-tray-appindicator'
     'plasma-desktop' 'plasma-nm' 'plasma-pa' 'plasma-workspace' 'plasma-workspace-wallpapers' 'powerdevil' 'qtcurve-gtk2' 'qtcurve-qt4'


### PR DESCRIPTION
Packages were renamed/replaced upstream:
kdenetwork-kopete -> kopete
kdeutils-sweeper -> sweeper

Closes #264