### PR TITLE
[addpkg] dbeaver-ce

### DIFF
--- a/antergos/dbeaver-ce/.SRCINFO
+++ b/antergos/dbeaver-ce/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dbeaver-ce
 	pkgdesc = DBeaver Community Edition is free and open source universal database tool for developers and database administrators.
-	pkgver = 4.3.2
+	pkgver = 4.3.3.1
 	pkgrel = 1
 	url = http://dbeaver.com/
 	install = dbeaver-ce.install
@@ -9,11 +9,11 @@ pkgbase = dbeaver-ce
 	depends = jre9-openjdk
 	depends = gtk2
 	depends = gtk-update-icon-cache
-	noextract = dbeaver-ce-4.3.2-linux.gtk.x86_64.tar.gz
-	source = https://github.com/dbeaver/dbeaver/releases/download/4.3.2/dbeaver-ce-4.3.2-linux.gtk.x86_64.tar.gz
+	noextract = dbeaver-ce-4.3.3.1-linux.gtk.x86_64.tar.gz
+	source = https://github.com/dbeaver/dbeaver/releases/download/4.3.3.1/dbeaver-ce-4.3.3.1-linux.gtk.x86_64.tar.gz
 	source = dbeaver-ce.desktop
 	source = dbeaver-ce.install
-	sha256sums = 7ad0bbca914aba53c9abd8c6e3a0e0439cd592b4318380b1a017b2de4ae7f16a
+	sha256sums = c5f3676c484c9ccd28e87c3cfe51621077b45e00ec9c06236acc97cddec39d8e
 	sha256sums = 64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c
 	sha256sums = 0c2a75baa39459fa56159e982d9f28c966837561bd52dffd24bac87b8d65555f
 

--- a/antergos/dbeaver-ce/.SRCINFO
+++ b/antergos/dbeaver-ce/.SRCINFO
@@ -4,22 +4,18 @@ pkgbase = dbeaver-ce
 	pkgrel = 1
 	url = http://dbeaver.com/
 	install = dbeaver-ce.install
-	arch = i686
 	arch = x86_64
 	license = GPL
 	depends = jre9-openjdk
 	depends = gtk2
 	depends = gtk-update-icon-cache
-	noextract = dbeaver-ce-4.3.2-linux.gtk.x86.tar.gz
 	noextract = dbeaver-ce-4.3.2-linux.gtk.x86_64.tar.gz
+	source = https://github.com/dbeaver/dbeaver/releases/download/4.3.2/dbeaver-ce-4.3.2-linux.gtk.x86_64.tar.gz
 	source = dbeaver-ce.desktop
 	source = dbeaver-ce.install
+	sha256sums = 7ad0bbca914aba53c9abd8c6e3a0e0439cd592b4318380b1a017b2de4ae7f16a
 	sha256sums = 64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c
 	sha256sums = 0c2a75baa39459fa56159e982d9f28c966837561bd52dffd24bac87b8d65555f
-	source_i686 = https://github.com/dbeaver/dbeaver/releases/download/4.3.2/dbeaver-ce-4.3.2-linux.gtk.x86.tar.gz
-	sha256sums_i686 = ff482ba2064cfd693922b8f4109c722a26365f53d7a141b601cc585b29f7481e
-	source_x86_64 = https://github.com/dbeaver/dbeaver/releases/download/4.3.2/dbeaver-ce-4.3.2-linux.gtk.x86_64.tar.gz
-	sha256sums_x86_64 = 7ad0bbca914aba53c9abd8c6e3a0e0439cd592b4318380b1a017b2de4ae7f16a
 
 pkgname = dbeaver-ce
 

--- a/antergos/dbeaver-ce/.SRCINFO
+++ b/antergos/dbeaver-ce/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dbeaver-ce
 	pkgdesc = DBeaver Community Edition is free and open source universal database tool for developers and database administrators.
-	pkgver = 4.3.4
+	pkgver = 4.3.5
 	pkgrel = 1
 	url = http://dbeaver.com/
 	install = dbeaver-ce.install
@@ -9,11 +9,11 @@ pkgbase = dbeaver-ce
 	depends = jre9-openjdk
 	depends = gtk2
 	depends = gtk-update-icon-cache
-	noextract = dbeaver-ce-4.3.4-linux.gtk.x86_64.tar.gz
-	source = https://github.com/dbeaver/dbeaver/releases/download/4.3.4/dbeaver-ce-4.3.4-linux.gtk.x86_64.tar.gz
+	noextract = dbeaver-ce-4.3.5-linux.gtk.x86_64.tar.gz
+	source = https://github.com/dbeaver/dbeaver/releases/download/4.3.5/dbeaver-ce-4.3.5-linux.gtk.x86_64.tar.gz
 	source = dbeaver-ce.desktop
 	source = dbeaver-ce.install
-	sha256sums = c7d7ea12a9ce9f115228dba36c44d52eab5817c47abd78a49a88d2692c1e8833
+	sha256sums = c1a3f08c34de8cea8076acc1b2709860bacd9b2861d006f81efa33fbdbde47b6
 	sha256sums = 64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c
 	sha256sums = 0c2a75baa39459fa56159e982d9f28c966837561bd52dffd24bac87b8d65555f
 

--- a/antergos/dbeaver-ce/.SRCINFO
+++ b/antergos/dbeaver-ce/.SRCINFO
@@ -1,0 +1,25 @@
+pkgbase = dbeaver-ce
+	pkgdesc = DBeaver Community Edition is free and open source universal database tool for developers and database administrators.
+	pkgver = 4.3.2
+	pkgrel = 1
+	url = http://dbeaver.com/
+	install = dbeaver-ce.install
+	arch = i686
+	arch = x86_64
+	license = GPL
+	depends = jre9-openjdk
+	depends = gtk2
+	depends = gtk-update-icon-cache
+	noextract = dbeaver-ce-4.3.2-linux.gtk.x86.tar.gz
+	noextract = dbeaver-ce-4.3.2-linux.gtk.x86_64.tar.gz
+	source = dbeaver-ce.desktop
+	source = dbeaver-ce.install
+	sha256sums = 64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c
+	sha256sums = 0c2a75baa39459fa56159e982d9f28c966837561bd52dffd24bac87b8d65555f
+	source_i686 = https://github.com/dbeaver/dbeaver/releases/download/4.3.2/dbeaver-ce-4.3.2-linux.gtk.x86.tar.gz
+	sha256sums_i686 = ff482ba2064cfd693922b8f4109c722a26365f53d7a141b601cc585b29f7481e
+	source_x86_64 = https://github.com/dbeaver/dbeaver/releases/download/4.3.2/dbeaver-ce-4.3.2-linux.gtk.x86_64.tar.gz
+	sha256sums_x86_64 = 7ad0bbca914aba53c9abd8c6e3a0e0439cd592b4318380b1a017b2de4ae7f16a
+
+pkgname = dbeaver-ce
+

--- a/antergos/dbeaver-ce/.SRCINFO
+++ b/antergos/dbeaver-ce/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dbeaver-ce
 	pkgdesc = DBeaver Community Edition is free and open source universal database tool for developers and database administrators.
-	pkgver = 4.3.3.1
+	pkgver = 4.3.4
 	pkgrel = 1
 	url = http://dbeaver.com/
 	install = dbeaver-ce.install
@@ -9,11 +9,11 @@ pkgbase = dbeaver-ce
 	depends = jre9-openjdk
 	depends = gtk2
 	depends = gtk-update-icon-cache
-	noextract = dbeaver-ce-4.3.3.1-linux.gtk.x86_64.tar.gz
-	source = https://github.com/dbeaver/dbeaver/releases/download/4.3.3.1/dbeaver-ce-4.3.3.1-linux.gtk.x86_64.tar.gz
+	noextract = dbeaver-ce-4.3.4-linux.gtk.x86_64.tar.gz
+	source = https://github.com/dbeaver/dbeaver/releases/download/4.3.4/dbeaver-ce-4.3.4-linux.gtk.x86_64.tar.gz
 	source = dbeaver-ce.desktop
 	source = dbeaver-ce.install
-	sha256sums = c5f3676c484c9ccd28e87c3cfe51621077b45e00ec9c06236acc97cddec39d8e
+	sha256sums = c7d7ea12a9ce9f115228dba36c44d52eab5817c47abd78a49a88d2692c1e8833
 	sha256sums = 64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c
 	sha256sums = 0c2a75baa39459fa56159e982d9f28c966837561bd52dffd24bac87b8d65555f
 

--- a/antergos/dbeaver-ce/.gitignore
+++ b/antergos/dbeaver-ce/.gitignore
@@ -1,0 +1,4 @@
+pkg/
+src/
+*.tar.gz
+*.pkg.tar

--- a/antergos/dbeaver-ce/PKGBUILD
+++ b/antergos/dbeaver-ce/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=dbeaver-ce
 pkgver=4.3.2
 pkgrel=1
 pkgdesc="DBeaver Community Edition is free and open source universal database tool for developers and database administrators."
-arch=('i686' 'x86_64')
+arch=('x86_64')
 url="http://dbeaver.com/"
 license=("GPL")
 depends=(
@@ -17,28 +17,21 @@ depends=(
 )
 install=dbeaver-ce.install
 source=(
+    https://github.com/dbeaver/dbeaver/releases/download/${pkgver}/dbeaver-ce-${pkgver}-linux.gtk.x86_64.tar.gz
     dbeaver-ce.desktop
     dbeaver-ce.install
 )
-source_i686=(https://github.com/dbeaver/dbeaver/releases/download/4.3.2/dbeaver-ce-4.3.2-linux.gtk.x86.tar.gz)
-source_x86_64=(https://github.com/dbeaver/dbeaver/releases/download/${pkgver}/dbeaver-ce-${pkgver}-linux.gtk.x86_64.tar.gz)
 
-sha256sums=('64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c'
+sha256sums=('7ad0bbca914aba53c9abd8c6e3a0e0439cd592b4318380b1a017b2de4ae7f16a'
+            '64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c'
             '0c2a75baa39459fa56159e982d9f28c966837561bd52dffd24bac87b8d65555f')
-sha256sums_i686=('ff482ba2064cfd693922b8f4109c722a26365f53d7a141b601cc585b29f7481e')
-sha256sums_x86_64=('7ad0bbca914aba53c9abd8c6e3a0e0439cd592b4318380b1a017b2de4ae7f16a')
 
-noextract=("dbeaver-ce-${pkgver}-linux.gtk.x86.tar.gz"
-           "dbeaver-ce-${pkgver}-linux.gtk.x86_64.tar.gz")
+noextract=("dbeaver-ce-${pkgver}-linux.gtk.x86_64.tar.gz")
 
 prepare() {
     mkdir -p $srcdir/$pkgname
     cd $srcdir/$pkgname
-    if [ "$CARCH" = "x86_64" ]; then
-        tar -xf "$srcdir/dbeaver-ce-${pkgver}-linux.gtk.x86_64.tar.gz"
-    else
-        tar -xf "$srcdir/dbeaver-ce-${pkgver}-linux.gtk.x86.tar.gz"
-    fi
+    tar -xf "$srcdir/dbeaver-ce-${pkgver}-linux.gtk.x86_64.tar.gz"
 }
 
 package() {

--- a/antergos/dbeaver-ce/PKGBUILD
+++ b/antergos/dbeaver-ce/PKGBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Curtis Belt <curtisbelt@gmail.com>
+# Previous Maintainer: Nenad Stojanovikj <nekk1 at live dot com>
+# Previous Maintainer: Joseph Post <joe@jcpst.com>
+# Previous Maintainer: Stephan Wienczny <stephan@wienczny.de>
+
+pkgname=dbeaver-ce
+pkgver=4.3.2
+pkgrel=1
+pkgdesc="DBeaver Community Edition is free and open source universal database tool for developers and database administrators."
+arch=('i686' 'x86_64')
+url="http://dbeaver.com/"
+license=("GPL")
+depends=(
+    'jre9-openjdk'
+    'gtk2'
+    'gtk-update-icon-cache'
+)
+install=dbeaver-ce.install
+source=(
+    dbeaver-ce.desktop
+    dbeaver-ce.install
+)
+source_i686=(https://github.com/dbeaver/dbeaver/releases/download/4.3.2/dbeaver-ce-4.3.2-linux.gtk.x86.tar.gz)
+source_x86_64=(https://github.com/dbeaver/dbeaver/releases/download/${pkgver}/dbeaver-ce-${pkgver}-linux.gtk.x86_64.tar.gz)
+
+sha256sums=('64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c'
+            '0c2a75baa39459fa56159e982d9f28c966837561bd52dffd24bac87b8d65555f')
+sha256sums_i686=('ff482ba2064cfd693922b8f4109c722a26365f53d7a141b601cc585b29f7481e')
+sha256sums_x86_64=('7ad0bbca914aba53c9abd8c6e3a0e0439cd592b4318380b1a017b2de4ae7f16a')
+
+noextract=("dbeaver-ce-${pkgver}-linux.gtk.x86.tar.gz"
+           "dbeaver-ce-${pkgver}-linux.gtk.x86_64.tar.gz")
+
+prepare() {
+    mkdir -p $srcdir/$pkgname
+    cd $srcdir/$pkgname
+    if [ "$CARCH" = "x86_64" ]; then
+        tar -xf "$srcdir/dbeaver-ce-${pkgver}-linux.gtk.x86_64.tar.gz"
+    else
+        tar -xf "$srcdir/dbeaver-ce-${pkgver}-linux.gtk.x86.tar.gz"
+    fi
+}
+
+package() {
+    cd $pkgdir
+    mkdir -p opt/
+    mkdir -p usr/bin
+    mkdir -p usr/share/applications
+    mkdir -p usr/share/icons/hicolor/48x48/apps
+
+    cp -r $srcdir/$pkgname/dbeaver opt/$pkgname
+    chmod +x opt/$pkgname/dbeaver
+    cp opt/$pkgname/icon.xpm usr/share/icons/hicolor/48x48/apps/${pkgname}.xpm
+    ln -s /opt/${pkgname}/dbeaver usr/bin/dbeaver-ce
+    install -m 644 $srcdir/dbeaver-ce.desktop $pkgdir/usr/share/applications/
+}

--- a/antergos/dbeaver-ce/PKGBUILD
+++ b/antergos/dbeaver-ce/PKGBUILD
@@ -4,7 +4,7 @@
 # Previous Maintainer: Stephan Wienczny <stephan@wienczny.de>
 
 pkgname=dbeaver-ce
-pkgver=4.3.3.1
+pkgver=4.3.4
 pkgrel=1
 pkgdesc="DBeaver Community Edition is free and open source universal database tool for developers and database administrators."
 arch=('x86_64')
@@ -22,7 +22,7 @@ source=(
     dbeaver-ce.install
 )
 
-sha256sums=('c5f3676c484c9ccd28e87c3cfe51621077b45e00ec9c06236acc97cddec39d8e'
+sha256sums=('c7d7ea12a9ce9f115228dba36c44d52eab5817c47abd78a49a88d2692c1e8833'
             '64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c'
             '0c2a75baa39459fa56159e982d9f28c966837561bd52dffd24bac87b8d65555f')
 

--- a/antergos/dbeaver-ce/PKGBUILD
+++ b/antergos/dbeaver-ce/PKGBUILD
@@ -4,7 +4,7 @@
 # Previous Maintainer: Stephan Wienczny <stephan@wienczny.de>
 
 pkgname=dbeaver-ce
-pkgver=4.3.4
+pkgver=4.3.5
 pkgrel=1
 pkgdesc="DBeaver Community Edition is free and open source universal database tool for developers and database administrators."
 arch=('x86_64')
@@ -22,7 +22,7 @@ source=(
     dbeaver-ce.install
 )
 
-sha256sums=('c7d7ea12a9ce9f115228dba36c44d52eab5817c47abd78a49a88d2692c1e8833'
+sha256sums=('c1a3f08c34de8cea8076acc1b2709860bacd9b2861d006f81efa33fbdbde47b6'
             '64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c'
             '0c2a75baa39459fa56159e982d9f28c966837561bd52dffd24bac87b8d65555f')
 

--- a/antergos/dbeaver-ce/PKGBUILD
+++ b/antergos/dbeaver-ce/PKGBUILD
@@ -4,7 +4,7 @@
 # Previous Maintainer: Stephan Wienczny <stephan@wienczny.de>
 
 pkgname=dbeaver-ce
-pkgver=4.3.2
+pkgver=4.3.3.1
 pkgrel=1
 pkgdesc="DBeaver Community Edition is free and open source universal database tool for developers and database administrators."
 arch=('x86_64')
@@ -22,7 +22,7 @@ source=(
     dbeaver-ce.install
 )
 
-sha256sums=('7ad0bbca914aba53c9abd8c6e3a0e0439cd592b4318380b1a017b2de4ae7f16a'
+sha256sums=('c5f3676c484c9ccd28e87c3cfe51621077b45e00ec9c06236acc97cddec39d8e'
             '64617581229a03d5a690a9995fa7cacb574bc17a028392c98589cccbb31f5c3c'
             '0c2a75baa39459fa56159e982d9f28c966837561bd52dffd24bac87b8d65555f')
 

--- a/antergos/dbeaver-ce/README.md
+++ b/antergos/dbeaver-ce/README.md
@@ -1,0 +1,14 @@
+# Update package
+
+* Update package version in PKGBUILD
+* Generate new checksums with
+
+```$ updpkgsums```
+
+* Test install
+
+```$ makepkg -si```
+
+* Update .SRCINFO
+
+```$ makepkg --printsrcinfo > .SRCINFO```

--- a/antergos/dbeaver-ce/dbeaver-ce.desktop
+++ b/antergos/dbeaver-ce/dbeaver-ce.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Exec=/opt/dbeaver-ce/dbeaver
+Type=Application
+Terminal=false
+Icon=dbeaver-ce
+Categories=Development;Java;Database;
+Name=DBeaver Community Edition
+GenericName=Database Client

--- a/antergos/dbeaver-ce/dbeaver-ce.install
+++ b/antergos/dbeaver-ce/dbeaver-ce.install
@@ -1,0 +1,12 @@
+post_install() {
+    gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
+}
+
+post_upgrade() {
+    post_install $1
+}
+
+post_remove() {
+    post_install $1
+}
+


### PR DESCRIPTION
## Feedback Needed
- DBeaver requires Java 1.8 or higher, but I went ahead and set the latest "jre9-openjdk" as the dependency to avoid having to select between versions during install. If it's frowned upon to not put the exact dependency, let me know.
- This is my first time creating a package, so any other review or feedback appreciated!

## Notes
- Used it myself successfully on two machines (x86_64)
- Adapted from https://aur.archlinux.org/cgit/aur.git/tree/?h=dbeaver-ce, retaining the previous maintainer credits.