### PR TITLE
Update aurman to 2.12

### DIFF
--- a/antergos/aurman/PKGBUILD
+++ b/antergos/aurman/PKGBUILD
@@ -2,8 +2,8 @@
 # AUR Maintainer: Jonni Westphalen <jonny.westphalen@googlemail.com>
 
 pkgname=aurman
-pkgver=2.10
-pkgrel=2
+pkgver=2.12
+pkgrel=1
 pkgdesc="aurman AUR helper with almost pacman syntax"
 arch=('any')
 url="https://github.com/polygamma/aurman"


### PR DESCRIPTION
Dropping the package should be considered, as its developer explicitly says, that he won't support Antergos, as per https://github.com/polygamma/aurman/issues/168#issuecomment-397979444