### PR TITLE
Fix #361 by changing a dependency

### DIFF
--- a/antergos/antergos-common-meta/PKGBUILD
+++ b/antergos/antergos-common-meta/PKGBUILD
@@ -10,7 +10,7 @@ license=('GPL3')
 depends=('accountsservice' 'antergos-wallpapers' 'antergos-desktop-settings'
     'cdrtools' 'dconf-editor' 'ffmpegthumbnailer' 'gst-libav' 'gst-plugins-bad'
     'gst-plugins-base' 'gst-plugins-good' 'gst-plugins-ugly' 'gstreamer-vaapi'
-    'hunspell-de' 'hunspell-en' 'hunspell-es' 'hunspell-fr' 'hunspell-he'
+    'hunspell-de' 'hunspell-en' 'hunspell-es_any' 'hunspell-fr' 'hunspell-he'
     'hunspell-it' 'hunspell-ro' 'hunspell-el' 'hunspell-hu' 'hunspell-nl'
     'hunspell-pl' 'libdvdcss' 'lightdm' 'lightdm-webkit2-greeter' 'light-locker'
     'light-locker-settings' 'mesa' 'mesa-vdpau' 'numix-frost-themes'

--- a/antergos/antergos-common-meta/PKGBUILD
+++ b/antergos/antergos-common-meta/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Antergos Devs <devs@antergos.com>
 
 pkgname=antergos-common-meta
-pkgver=1.1
+pkgver=1.2
 pkgrel=1
 pkgdesc='Common meta package for all Antergos Desktops'
 url='http://www.antergos.com'


### PR DESCRIPTION
An error occurs when attempting to update an Antergos system, because the `hunspell-es` package has been renamed to `hunspell-es_any`. Here is the output of `aurman -Syu`:

```
:: Synchronizing package databases...
 antergos is up to date
 core is up to date
 extra                                                                                               1651.6 KiB  5.70M/s 00:00 [#############################################################################] 100%
 community                                                                                              4.5 MiB  22.3M/s 00:00 [#############################################################################] 100%
 multilib is up to date
:: Starting full system upgrade...
:: Replace hunspell-es with extra/hunspell-es_any? [Y/n] 
resolving dependencies...
looking for conflicting packages...
error: failed to prepare transaction (could not satisfy dependencies)
:: removing hunspell-es breaks dependency 'hunspell-es' required by antergos-common-meta
2018-07-17 22:58:18,248 - wrappers - pacman - ERROR - pacman query sudo pacman --sync --refresh --sysupgrade failed
```