### PR TITLE
Bump SPL, ZFS versions to 0.7.12

### DIFF
--- a/antergos/spl-utils/PKGBUILD
+++ b/antergos/spl-utils/PKGBUILD
@@ -2,8 +2,8 @@
 # Contributor: isiachi <isiachi@rhyeworld.it>
 
 pkgname=spl-utils
-_pkgver=0.7.11
-pkgver=0.7.11
+_pkgver=0.7.12
+pkgver=0.7.12
 pkgrel=1
 license=('CDDL')
 pkgdesc="Kernel module support files for the Solaris Porting Layer."
@@ -18,7 +18,7 @@ _tag="spl-${_pkgver}"
 source=(
 	"https://github.com/zfsonlinux/spl/archive/${_tag}.zip"
 )
-md5sums=('9c87b505cf1000fae9c43eba4d89e141')
+md5sums=('ba3e634ef2f8218b9101e6b733f768ad')
 
 # BEGIN ANTBS METADATA
 _is_monitored='True'

--- a/antergos/spl/PKGBUILD
+++ b/antergos/spl/PKGBUILD
@@ -2,8 +2,8 @@
 # Contributor: isiachi <isiachi@rhyeworld.it>
 
 pkgname=spl
-_pkgver=0.7.11
-pkgver=0.7.11
+_pkgver=0.7.12
+pkgver=0.7.12
 pkgrel=1
 pkgdesc="Solaris Porting Layer kernel modules."
 groups=("system" "zfs")
@@ -20,7 +20,7 @@ _tag="spl-${_pkgver}"
 source=(
 	"https://github.com/zfsonlinux/${pkgname}/archive/${_tag}.zip"
 )
-md5sums=('9c87b505cf1000fae9c43eba4d89e141')
+md5sums=('ba3e634ef2f8218b9101e6b733f768ad')
 
 # BEGIN ANTBS METADATA
 _is_monitored='True'

--- a/antergos/zfs-utils/PKGBUILD
+++ b/antergos/zfs-utils/PKGBUILD
@@ -2,8 +2,8 @@
 # Contributor: isiachi <isiachi@rhyeworld.it>
 
 pkgname=zfs-utils
-_pkgver=0.7.11
-pkgver=0.7.11
+_pkgver=0.7.12
+pkgver=0.7.12
 pkgrel=1
 pkgdesc="Kernel module support files for the Zettabyte File System."
 url="http://zfsonlinux.org/"
@@ -20,7 +20,7 @@ source=(
 	"zfs-utils.initcpio.install"
 	"zfs-utils.initcpio.hook"
 )
-md5sums=('f0afbc265d63b3cd4a8459df4da5a44e'
+md5sums=('bb1b4076abac5e17aa9b6759683839dc'
          '9ddb0c8a94861f929d0fa741fdc49950'
          '73527e326fbbd1bc3d4331bbba0af5a8'
          '2d4dd00dd671598c26b5d054bd63d6f5')

--- a/antergos/zfs/PKGBUILD
+++ b/antergos/zfs/PKGBUILD
@@ -2,8 +2,8 @@
 # Contributor: isiachi <isiachi@rhyeworld.it>
 
 pkgname=zfs
-_pkgver=0.7.11
-pkgver=0.7.11
+_pkgver=0.7.12
+pkgver=0.7.12
 pkgrel=1
 pkgdesc="Kernel modules for the Zettabyte File System."
 license=('CDDL')
@@ -20,7 +20,7 @@ _tag="zfs-${_pkgver}"
 source=(
 	"https://github.com/zfsonlinux/${pkgname}/archive/${_tag}.zip"
 )
-md5sums=('f0afbc265d63b3cd4a8459df4da5a44e')
+md5sums=('bb1b4076abac5e17aa9b6759683839dc')
 
 
 # BEGIN ANTBS METADATA


### PR DESCRIPTION
Fixes #403 

Tested locally with kernel 4.19.2 and kernel-lts 4.14.81.