### PR TITLE
[jetbrains-toolbox] skip lost+found dir

### DIFF
--- a/antergos/jetbrains-toolbox/jetbrains-toolbox.install
+++ b/antergos/jetbrains-toolbox/jetbrains-toolbox.install
@@ -6,6 +6,9 @@ post_install() {
 
 	for home_dir in /home/*
 	do
+		if [ $home_dir = "/home/lost+found" ]; then
+    			continue
+		fi
 		autostart="${home_dir}/.config/autostart/jetbrains-toolbox.desktop"
 		local_share="${home_dir}/.local/share/applications/jetbrains-toolbox.desktop"
 

--- a/antergos/jetbrains-toolbox/jetbrains-toolbox.install
+++ b/antergos/jetbrains-toolbox/jetbrains-toolbox.install
@@ -6,9 +6,8 @@ post_install() {
 
 	for home_dir in /home/*
 	do
-		if [ $home_dir = "/home/lost+found" ]; then
-    			continue
-		fi
+		[[ '/home/lost+found' = "${home_dir}" ]] && continue;
+
 		autostart="${home_dir}/.config/autostart/jetbrains-toolbox.desktop"
 		local_share="${home_dir}/.local/share/applications/jetbrains-toolbox.desktop"
 


### PR DESCRIPTION
When updating, this package throws this error (It's not fatal but annoying)

```
cp: cannot create regular file '/home/lost+found/.config/autostart/jetbrains-toolbox.desktop': No such file or directory                                                                                                            
chmod: cannot access '/home/lost+found/.config/autostart/jetbrains-toolbox.desktop': No such file or directory
chmod: cannot access '/home/lost+found/.local/share/applications/jetbrains-toolbox.desktop': No such file or directory                                                                                                              
error: command failed to execute correctly
```