### PR TITLE
Update gnome-shell-extension-dash-to-panel

### DIFF
--- a/antergos/gnome-shell-extension-dash-to-panel/PKGBUILD
+++ b/antergos/gnome-shell-extension-dash-to-panel/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=gnome-shell-extension-dash-to-panel
 _name=dash-to-panel
-pkgver=16
+pkgver=19
 pkgrel=1
 pkgdesc='Extension for GNOME shell to combine the dash and main panel'
 arch=(any)
@@ -12,7 +12,7 @@ url="https://github.com/jderose9/dash-to-panel"
 license=(GPL2)
 makedepends=(git gnome-common intltool make)
 source=("https://github.com/jderose9/dash-to-panel/archive/v${pkgver}.tar.gz")
-sha256sums=('72e41fdfab020e0e54a7e6b02b44d505d9090829cb11b153ef7a654d05965261')
+sha256sums=('66e74182bddc507e4eae2d4061493b02de761a420f3b9c37c15194eef0639b5b')
 
 build() {
     cd "${srcdir}/${_name}-${pkgver}"


### PR DESCRIPTION
Update to latest version 19.1 as the current version 16.1 doesn't work with the latest version of GNOME anymore