### PR TITLE
replaced gamin  with gvfs

### DIFF
--- a/antergos/antergos-xfce-meta/PKGBUILD
+++ b/antergos/antergos-xfce-meta/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc='Meta package for Antergos Xfce'
 url='http://www.antergos.com'
 arch=('any')
 license=('GPL3')
-depends=('catfish' 'evince' 'file-roller' 'gamin' 'gnome-calculator' 'gnome-disk-utility'
+depends=('catfish' 'evince' 'file-roller' 'gvfs' 'gnome-calculator' 'gnome-disk-utility'
     'gnome-keyring' 'gnome-screensaver' 'gtk-engine-murrine' 'gvfs-google' 'gvfs-mtp'
     'mousepad' 'network-manager-applet' 'networkmanager-openvpn' 'networkmanager-pptp'
     'pamac' 'parole' 'python-pysmbc' 'polkit-gnome' 'pragha' 'qt5ct' 'ristretto'


### PR DESCRIPTION
replaced gamin (moved to AUR) with gvfs optional dependency for Thunar.
gamin is also not listed as an optional dependency for Thunar.

I can see: gamin (optional) – for monitoring file changes without gvfs at thunar-extended package deps...